### PR TITLE
Update paper reference to arXiv:2602.17112 in video_report_generation_ideas.md

### DIFF
--- a/md-files/video_report_generation_ideas.md
+++ b/md-files/video_report_generation_ideas.md
@@ -54,7 +54,7 @@ graph TB
 
 **Inspired by**: 
 - Pang et al. (2023) - "A survey on automatic generation of medical imaging reports based on deep learning" (PMC)
-- Artificial Intelligence Review (2025) - "Automatic radiology report generation with deep learning: a comprehensive review"
+- arXiv (2026) - "arXiv:2602.17112" (https://arxiv.org/abs/2602.17112)
 
 **Key insight**: Training medical image captioning models requires careful data preprocessing, multi-stage encoding (frame→temporal→study), and iterative validation with both NLG and clinical efficacy metrics.
 
@@ -520,7 +520,7 @@ graph TB
 
 2. **Pang, T., Li, P., & Zhao, L. (2023)**. "A survey on automatic generation of medical imaging reports based on deep learning." *Biomedical Engineering Online*. PMC10195007
 
-3. **Artificial Intelligence Review (2025)**. "Automatic radiology report generation with deep learning: a comprehensive review of methods and advances."
+3. **arXiv (2026)**. "arXiv:2602.17112". https://arxiv.org/abs/2602.17112
 
 ### Vision-Language Foundation Models:
 4. **Xu, K., Ba, J., Kiros, R., Cho, K., Courville, A., Salakhutdinov, R., Zemel, R., & Bengio, Y. (2015)**. "Show, Attend and Tell: Neural Image Caption Generation with Visual Attention." *ICML 2015*. https://arxiv.org/abs/1502.03044


### PR DESCRIPTION
### Motivation
- Replace an older review citation in the training pipeline / paper section with the newly provided arXiv paper identifier and URL so the document points to `arXiv:2602.17112`.

### Description
- Edited `md-files/video_report_generation_ideas.md` to replace the line referencing "Artificial Intelligence Review (2025) - Automatic radiology report generation with deep learning: a comprehensive review" with `arXiv (2026) - "arXiv:2602.17112" (https://arxiv.org/abs/2602.17112)` in both the "Inspired by" list and the "Key Research Papers Referenced" list.

### Testing
- Verified the change by searching the file with `rg` to confirm the old reference is no longer present and the new `2602.17112` identifier and URL appear in the expected locations, and inspected the file diff to confirm only the intended replacement was made (all checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8d77a894832ab2e1f97c568da24f)