### PR TITLE
Fix module import error in fine-tuning/test.py

### DIFF
--- a/fine-tuning/test.py
+++ b/fine-tuning/test.py
@@ -1,4 +1,11 @@
-from AngioVision.configs.questions import QA_QUESTIONS
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from configs.questions import QA_QUESTIONS
 
 print("Hello")
 print(QA_QUESTIONS)


### PR DESCRIPTION
### Motivation
- Allow `fine-tuning/test.py` to be executed directly from the repository root without raising a `ModuleNotFoundError` when importing `configs.questions`.

### Description
- Prepend the repository root to `sys.path` at runtime and import `QA_QUESTIONS` via `from configs.questions import QA_QUESTIONS` so the script runs reliably when invoked with `python3 fine-tuning/test.py`.

### Testing
- Ran `python3 fine-tuning/test.py` and confirmed it prints `Hello` and the `QA_QUESTIONS` list with a successful exit (no import errors).